### PR TITLE
Change List<T> to a ConcurrentBag<T>

### DIFF
--- a/src/Dianoga/Optimizers/CommandLineToolOptimizer.cs
+++ b/src/Dianoga/Optimizers/CommandLineToolOptimizer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -64,7 +65,7 @@ namespace Dianoga.Optimizers
 
 		protected virtual void ExecuteProcess(string arguments)
 		{
-			var processOutput = new List<string>();
+		    var processOutput = new ConcurrentBag<string>();
 
 			var processInfo = new ProcessStartInfo();
 			processInfo.UseShellExecute = false;


### PR DESCRIPTION
Change List<T> to a ConcurrentBag<T>. Was causing the AppPool to crash when trying to write an error to the log.

An exception would be logged in the Windows Application Event Log, then the worker process would crash. This is the exception which was being logged to the Event Log:

```
Message: Source array was not long enough. Check srcIndex and length, and the array's lower bounds.

StackTrace:    at System.Array.Copy(Array sourceArray, Int32 sourceIndex, Array destinationArray, Int32 destinationIndex, Int32 length, Boolean reliable)
   at System.Array.Copy(Array sourceArray, Int32 sourceIndex, Array destinationArray, Int32 destinationIndex, Int32 length)
   at System.Collections.Generic.List`1.set_Capacity(Int32 value)
   at System.Collections.Generic.List`1.EnsureCapacity(Int32 min)
   at System.Collections.Generic.List`1.Add(T item)
   at System.Diagnostics.Process.OutputReadNotifyUser(String data)
   at System.Diagnostics.AsyncStreamReader.FlushMessageQueue()
   at System.Diagnostics.AsyncStreamReader.ReadBuffer(IAsyncResult ar)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.IO.Stream.ReadWriteTask.System.Threading.Tasks.ITaskCompletionAction.Invoke(Task completingTask)
   at System.Threading.Tasks.Task.FinishContinuations()
   at System.Threading.Tasks.Task.FinishStageThree()
   at System.Threading.Tasks.Task.Finish(Boolean bUserDelegateExecuted)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot)
   at System.Threading.Tasks.Task.ExecuteEntry(Boolean bPreventDoubleExecution)
   at System.Threading.Tasks.Task.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
```

Making this changes solves this issue.

Thanks,
Dan.