### PR TITLE
Fix Access to the path 'C:\Windows\TEMP\tmpXXXX.tmp' is denied. #18

### DIFF
--- a/src/Dianoga.Tests/Optimizers/Pipelines/DianogaPng/PngOptimizerTests.cs
+++ b/src/Dianoga.Tests/Optimizers/Pipelines/DianogaPng/PngOptimizerTests.cs
@@ -8,8 +8,11 @@ namespace Dianoga.Tests.Optimizers.Pipelines.DianogaPng
 {
 	public class PngOptimizerTests
 	{
-		[Fact]
-		public void ShouldSquishTestPng()
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(@"..\..\..\Dianoga\Dianoga Tools\Temp")]
+        public void ShouldSquishTestPng(string TempFolder)
 		{
 			var inputStream = new MemoryStream();
 
@@ -20,8 +23,9 @@ namespace Dianoga.Tests.Optimizers.Pipelines.DianogaPng
 
 			var sut = new PngOptimizer();
 			sut.DllPath = @"..\..\..\Dianoga\Dianoga Tools\PNGOptimizer\PNGOptimizerDll.dll";
+		    sut.TempPath = TempFolder;
 
-			var args = new OptimizerArgs(inputStream);
+            var args = new OptimizerArgs(inputStream);
 
 			var startingSize = args.Stream.Length;
 

--- a/src/Dianoga.Tests/Optimizers/Pipelines/DianogaPng/PngOptimizerTests.cs
+++ b/src/Dianoga.Tests/Optimizers/Pipelines/DianogaPng/PngOptimizerTests.cs
@@ -12,7 +12,7 @@ namespace Dianoga.Tests.Optimizers.Pipelines.DianogaPng
         [InlineData(null)]
         [InlineData("")]
         [InlineData(@"..\..\..\Dianoga\Dianoga Tools\Temp")]
-        public void ShouldSquishTestPng(string TempFolder)
+        public void ShouldSquishTestPng(string tempFolder)
 		{
 			var inputStream = new MemoryStream();
 
@@ -23,7 +23,7 @@ namespace Dianoga.Tests.Optimizers.Pipelines.DianogaPng
 
 			var sut = new PngOptimizer();
 			sut.DllPath = @"..\..\..\Dianoga\Dianoga Tools\PNGOptimizer\PNGOptimizerDll.dll";
-		    sut.TempPath = TempFolder;
+		    sut.TempPath = tempFolder;
 
             var args = new OptimizerArgs(inputStream);
 

--- a/src/Dianoga/Default Config Files/Dianoga.Png.config
+++ b/src/Dianoga/Default Config Files/Dianoga.Png.config
@@ -5,50 +5,50 @@
 	(usually a non-noticeable image quality reduction)
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
-  <sitecore>
-    <pipelines>
-      <dianogaOptimize>
-        <!-- if adding new processors make sure they have a unique desc attribute -->
-        <processor type="Dianoga.Processors.Pipelines.DianogaOptimize.ExtensionBasedOptimizer, Dianoga" desc="png">
-          <Extensions>png</Extensions>
-          <Pipeline>dianogaOptimizePng</Pipeline>
-        </processor>
-      </dianogaOptimize>
+	<sitecore>
+		<pipelines>
+			<dianogaOptimize>
+				<!-- if adding new processors make sure they have a unique desc attribute -->
+				<processor type="Dianoga.Processors.Pipelines.DianogaOptimize.ExtensionBasedOptimizer, Dianoga" desc="png">
+					<Extensions>png</Extensions>
+					<Pipeline>dianogaOptimizePng</Pipeline>
+				</processor>
+			</dianogaOptimize>
 
-      <!-- 
+			<!-- 
 				DIANOGA OPTIMIZE PNG
 				Pipeline that defines how PNGs get optimized. Multiple optimizers may run over the same file.
 				Optimizers should derive from OptimizerProcessor or CommandLineToolOptimizer.
 				
 				Optimizers are expected to close the stream they receive under any circumstances!
 			-->
-      <dianogaOptimizePng>
-        <!-- 
+			<dianogaOptimizePng>
+				<!-- 
 				Enable this processor to allow PNG quantization (a lossy operation) in addition to PNG optimizer.
 				Run quantization first if you are doing both.
 				<processor type="Dianoga.Optimizers.Pipelines.DianogaPng.PngQuantOptimizer, Dianoga" />-->
-        <processor type="Dianoga.Optimizers.Pipelines.DianogaPng.PngOptimizer, Dianoga">
-          <DllPath>/App_Data/Dianoga Tools/PNGOptimizer/PNGOptimizerDll.dll</DllPath>
-          <!-- 
-          IMPORTANT
-          This process use a temporary folder to perform the optimizations.
-          Define temporary folder path and grant read/write access to Application Pool Identity User 
-          to avoid access and write errors.
+				<processor type="Dianoga.Optimizers.Pipelines.DianogaPng.PngOptimizer, Dianoga">
+					<DllPath>/App_Data/Dianoga Tools/PNGOptimizer/PNGOptimizerDll.dll</DllPath>
+					<!-- 
+					IMPORTANT
+					This process use a temporary folder to perform the optimizations.
+					Define temporary folder path and grant read/write access to Application Pool Identity User 
+					to avoid access and write errors.
 
-          If TempPath is empty or not defined, the GetTempPath function will be used trying to 
-          get the temp folder in this order:
-            1.- The path specified by the TMP environment variable
-            2.- The path specified by the TEMP environment variable
-            3.- The path specified by the USERPROFILE environment variable
-            4.- The Windows directory 
+					If TempPath is empty or not defined, the GetTempPath function will be used trying to 
+					get the temp folder in this order:
+					1.- The path specified by the TMP environment variable
+					2.- The path specified by the TEMP environment variable
+					3.- The path specified by the USERPROFILE environment variable
+					4.- The Windows directory 
 
-          Examples:
-            <TempPath>/App_Data/Dianoga Tools/Temp</TempPath> Folder is already included on Project
-            <TempPath></TempPath>                             Let to Windows choose the temporary folder
-          -->
-          <TempPath>/App_Data/Dianoga Tools/Temp</TempPath>
-        </processor>
-      </dianogaOptimizePng>
-    </pipelines>
-  </sitecore>
+					Examples:
+					<TempPath>/App_Data/Dianoga Tools/Temp</TempPath> Folder is already included on Project
+					<TempPath></TempPath>                             Let to Windows choose the temporary folder
+					-->
+					<TempPath>/App_Data/Dianoga Tools/Temp</TempPath>
+				</processor>
+			</dianogaOptimizePng>
+		</pipelines>
+	</sitecore>
 </configuration>

--- a/src/Dianoga/Default Config Files/Dianoga.Png.config
+++ b/src/Dianoga/Default Config Files/Dianoga.Png.config
@@ -5,32 +5,50 @@
 	(usually a non-noticeable image quality reduction)
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
-	<sitecore>
-		<pipelines>
-			<dianogaOptimize>
-				<!-- if adding new processors make sure they have a unique desc attribute -->
-				<processor type="Dianoga.Processors.Pipelines.DianogaOptimize.ExtensionBasedOptimizer, Dianoga" desc="png">
-					<Extensions>png</Extensions>
-					<Pipeline>dianogaOptimizePng</Pipeline>
-				</processor>
-			</dianogaOptimize>
+  <sitecore>
+    <pipelines>
+      <dianogaOptimize>
+        <!-- if adding new processors make sure they have a unique desc attribute -->
+        <processor type="Dianoga.Processors.Pipelines.DianogaOptimize.ExtensionBasedOptimizer, Dianoga" desc="png">
+          <Extensions>png</Extensions>
+          <Pipeline>dianogaOptimizePng</Pipeline>
+        </processor>
+      </dianogaOptimize>
 
-			<!-- 
+      <!-- 
 				DIANOGA OPTIMIZE PNG
 				Pipeline that defines how PNGs get optimized. Multiple optimizers may run over the same file.
 				Optimizers should derive from OptimizerProcessor or CommandLineToolOptimizer.
 				
 				Optimizers are expected to close the stream they receive under any circumstances!
 			-->
-			<dianogaOptimizePng>
-				<!-- 
+      <dianogaOptimizePng>
+        <!-- 
 				Enable this processor to allow PNG quantization (a lossy operation) in addition to PNG optimizer.
 				Run quantization first if you are doing both.
 				<processor type="Dianoga.Optimizers.Pipelines.DianogaPng.PngQuantOptimizer, Dianoga" />-->
-				<processor type="Dianoga.Optimizers.Pipelines.DianogaPng.PngOptimizer, Dianoga">
-					<DllPath>/App_Data/Dianoga Tools/PNGOptimizer/PNGOptimizerDll.dll</DllPath>
-				</processor>
-			</dianogaOptimizePng>
-		</pipelines>
-	</sitecore>
+        <processor type="Dianoga.Optimizers.Pipelines.DianogaPng.PngOptimizer, Dianoga">
+          <DllPath>/App_Data/Dianoga Tools/PNGOptimizer/PNGOptimizerDll.dll</DllPath>
+          <!-- 
+          IMPORTANT
+          This process use a temporary folder to perform the optimizations.
+          Define temporary folder path and grant read/write access to Application Pool Identity User 
+          to avoid access and write errors.
+
+          If TempPath is empty or not defined, the GetTempPath function will be used trying to 
+          get the temp folder in this order:
+            1.- The path specified by the TMP environment variable
+            2.- The path specified by the TEMP environment variable
+            3.- The path specified by the USERPROFILE environment variable
+            4.- The Windows directory 
+
+          Examples:
+            <TempPath>/App_Data/Dianoga Tools/Temp</TempPath> Folder is already included on Project
+            <TempPath></TempPath>                             Let to Windows choose the temporary folder
+          -->
+          <TempPath>/App_Data/Dianoga Tools/Temp</TempPath>
+        </processor>
+      </dianogaOptimizePng>
+    </pipelines>
+  </sitecore>
 </configuration>

--- a/src/Dianoga/Dianoga Tools/Temp/Readme.txt
+++ b/src/Dianoga/Dianoga Tools/Temp/Readme.txt
@@ -1,0 +1,1 @@
+﻿Create Temp Folder to be used by Optimization process 

--- a/src/Dianoga/Dianoga.csproj
+++ b/src/Dianoga/Dianoga.csproj
@@ -96,7 +96,9 @@
     <None Include="Dianoga.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Content Include="Dianoga Tools\Temp\Readme.txt" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Dianoga/Optimizers/Pipelines/DianogaPng/PngOptimizer.cs
+++ b/src/Dianoga/Optimizers/Pipelines/DianogaPng/PngOptimizer.cs
@@ -11,9 +11,11 @@ namespace Dianoga.Optimizers.Pipelines.DianogaPng
 	{
 		public string DllPath { private get; set; }
 
-		protected override void ProcessOptimizer(OptimizerArgs args)
+        public string TempPath { get; set; }
+
+        protected override void ProcessOptimizer(OptimizerArgs args)
 		{
-			using (var pngOptimizer = new DynamicLinkLibrary(DllPath))
+			using (var pngOptimizer = new DynamicLinkLibrary(DllPath, TempPath))
 			{
 				using (var memoryStream = new MemoryStream())
 				{
@@ -40,7 +42,7 @@ namespace Dianoga.Optimizers.Pipelines.DianogaPng
 			}
 		}
 
-		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+	    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		private delegate bool OptimizeBytes(byte[] image, int imageSize, [Out] byte[] result, int resultCapacity, out int resultSize);
 
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/src/Dianoga/Optimizers/Pipelines/DianogaPng/PngOptimizer.cs
+++ b/src/Dianoga/Optimizers/Pipelines/DianogaPng/PngOptimizer.cs
@@ -11,9 +11,9 @@ namespace Dianoga.Optimizers.Pipelines.DianogaPng
 	{
 		public string DllPath { private get; set; }
 
-        public string TempPath { get; set; }
+		public string TempPath { get; set; }
 
-        protected override void ProcessOptimizer(OptimizerArgs args)
+		protected override void ProcessOptimizer(OptimizerArgs args)
 		{
 			using (var pngOptimizer = new DynamicLinkLibrary(DllPath, TempPath))
 			{
@@ -42,7 +42,7 @@ namespace Dianoga.Optimizers.Pipelines.DianogaPng
 			}
 		}
 
-	    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		private delegate bool OptimizeBytes(byte[] image, int imageSize, [Out] byte[] result, int resultCapacity, out int resultSize);
 
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/src/Dianoga/Unmanaged/DynamicLinkLibrary.cs
+++ b/src/Dianoga/Unmanaged/DynamicLinkLibrary.cs
@@ -2,92 +2,111 @@
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Web.Hosting;
+using Sitecore.StringExtensions;
 
 namespace Dianoga.Unmanaged
 {
-	public class DynamicLinkLibrary : IDisposable
-	{
-		private readonly string _originalPathToDll;
-		private readonly object _loaderLock = new object();
-		private string _tempPathToDll;
-		private IntPtr _pointerLibrary;
+    public class DynamicLinkLibrary : IDisposable
+    {
+        private readonly string _tempPath;
+        private readonly string _originalPathToDll;
+        private readonly object _loaderLock = new object();
+        private string _tempPathToDll;
+        private IntPtr _pointerLibrary;
 
-		public DynamicLinkLibrary(string pathToDll)
-		{
-			_originalPathToDll = pathToDll.StartsWith("~") || pathToDll.StartsWith("/")
-				? HostingEnvironment.MapPath(pathToDll)
-				: pathToDll;
+        public DynamicLinkLibrary(string pathToDll, string tempPath)
+        {
+            _tempPath = tempPath;
+            _originalPathToDll = GetFilePath(pathToDll);
 
-			_pointerLibrary = LoadModule();
-		}
+            _pointerLibrary = LoadModule();
+        }
 
-		private IntPtr LoadModule()
-		{
-			lock (_loaderLock)
-			{
-				if (_pointerLibrary != IntPtr.Zero) return _pointerLibrary;
+        private IntPtr LoadModule()
+        {
+            lock (_loaderLock)
+            {
+                if (_pointerLibrary != IntPtr.Zero) return _pointerLibrary;
 
-				if (!File.Exists(_originalPathToDll))
-				{
-					throw new FileNotFoundException($"Unable to load DLL from {_originalPathToDll}");
-				}
+                if (!File.Exists(_originalPathToDll))
+                {
+                    throw new FileNotFoundException($"Unable to load DLL from {_originalPathToDll}");
+                }
 
-				_tempPathToDll = Path.GetTempFileName();
+                _tempPathToDll = GetTempPathByConfig();
 
-				CopyFile();
+                CopyFile();
 
-				_pointerLibrary = NativeMethods.LoadLibrary(_tempPathToDll);
+                _pointerLibrary = NativeMethods.LoadLibrary(_tempPathToDll);
 
-				if (_pointerLibrary == IntPtr.Zero)
-				{
-					throw new Exception($"Unable to load DLL from {_originalPathToDll}");
-				}
+                if (_pointerLibrary == IntPtr.Zero)
+                {
+                    throw new Exception($"Unable to load DLL from {_originalPathToDll}");
+                }
 
-				return _pointerLibrary;
-			}
-		}
+                return _pointerLibrary;
+            }
+        }
 
-		private void CopyFile()
-		{
-			using (var stream = File.OpenRead(_originalPathToDll))
-			using (var writeStream = new FileStream(_tempPathToDll, FileMode.Create, FileAccess.Write))
-			{
-				stream.Seek(0, SeekOrigin.Begin);
-				stream.CopyTo(writeStream);
-			}
-		}
+        private static string GetFilePath(string pathToDll)
+        {
+            return pathToDll.StartsWith("~") || pathToDll.StartsWith("/")
+                ? HostingEnvironment.MapPath(pathToDll)
+                : pathToDll;
+        }
 
-		private IntPtr LoadMethodOrFunction(string name)
-		{
-			var addressOfMethod = NativeMethods.GetProcAddress(_pointerLibrary, name);
-			if (addressOfMethod == IntPtr.Zero)
-			{
-				throw new Exception("Can't find {functionName} funtion in {originalPathToDll}");
-			}
+        private string GetTempPathByConfig()
+        {
+            if (_tempPath.IsNullOrEmpty())
+                return Path.GetTempFileName();
 
-			return addressOfMethod;
-		}
+            var tempPathFixed = !_tempPath.EndsWith(@"\") ? _tempPath + @"\" : _tempPath;
+            tempPathFixed = GetFilePath(tempPathFixed);
 
-		public object GetDelegateFunction(string functionName, Type type)
-		{
-			var addressOfMethod = LoadMethodOrFunction(functionName);
-			var method = Marshal.GetDelegateForFunctionPointer(addressOfMethod, type);
-			return method;
-		}
+            return $@"{tempPathFixed}\{Path.GetRandomFileName()}";
+        }
 
-		public void Dispose()
-		{
-			//Dispose the library
-			if (_pointerLibrary != IntPtr.Zero)
-			{
-				NativeMethods.FreeLibrary(_pointerLibrary);
-			}
+        private void CopyFile()
+        {
+            using (var stream = File.OpenRead(_originalPathToDll))
+            using (var writeStream = new FileStream(_tempPathToDll, FileMode.Create, FileAccess.Write))
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+                stream.CopyTo(writeStream);
+            }
+        }
 
-			//Delete temporary File
-			if (File.Exists(_tempPathToDll))
-			{
-				File.Delete(_tempPathToDll);
-			}
-		}
-	}
+        private IntPtr LoadMethodOrFunction(string name)
+        {
+            var addressOfMethod = NativeMethods.GetProcAddress(_pointerLibrary, name);
+            if (addressOfMethod == IntPtr.Zero)
+            {
+                throw new Exception("Can't find {functionName} funtion in {originalPathToDll}");
+            }
+
+            return addressOfMethod;
+        }
+
+        public object GetDelegateFunction(string functionName, Type type)
+        {
+            var addressOfMethod = LoadMethodOrFunction(functionName);
+            var method = Marshal.GetDelegateForFunctionPointer(addressOfMethod, type);
+            return method;
+        }
+
+        public void Dispose()
+        {
+            //Dispose the library
+            if (_pointerLibrary != IntPtr.Zero)
+            {
+                NativeMethods.FreeLibrary(_pointerLibrary);
+            }
+
+            //Delete temporary File
+            if (File.Exists(_tempPathToDll))
+            {
+                File.Delete(_tempPathToDll);
+            }
+        }
+    }
 }

--- a/src/Dianoga/Unmanaged/DynamicLinkLibrary.cs
+++ b/src/Dianoga/Unmanaged/DynamicLinkLibrary.cs
@@ -6,107 +6,107 @@ using Sitecore.StringExtensions;
 
 namespace Dianoga.Unmanaged
 {
-    public class DynamicLinkLibrary : IDisposable
-    {
-        private readonly string _tempPath;
-        private readonly string _originalPathToDll;
-        private readonly object _loaderLock = new object();
-        private string _tempPathToDll;
-        private IntPtr _pointerLibrary;
+	public class DynamicLinkLibrary : IDisposable
+	{
+		private readonly string _tempPath;
+		private readonly string _originalPathToDll;
+		private readonly object _loaderLock = new object();
+		private string _tempPathToDll;
+		private IntPtr _pointerLibrary;
 
-        public DynamicLinkLibrary(string pathToDll, string tempPath)
-        {
-            _tempPath = tempPath;
-            _originalPathToDll = GetFilePath(pathToDll);
+		public DynamicLinkLibrary(string pathToDll, string tempPath)
+		{
+			_tempPath = tempPath;
+			_originalPathToDll = GetFilePath(pathToDll);
 
-            _pointerLibrary = LoadModule();
-        }
+			_pointerLibrary = LoadModule();
+		}
 
-        private IntPtr LoadModule()
-        {
-            lock (_loaderLock)
-            {
-                if (_pointerLibrary != IntPtr.Zero) return _pointerLibrary;
+		private IntPtr LoadModule()
+		{
+			lock (_loaderLock)
+			{
+				if (_pointerLibrary != IntPtr.Zero) return _pointerLibrary;
 
-                if (!File.Exists(_originalPathToDll))
-                {
-                    throw new FileNotFoundException($"Unable to load DLL from {_originalPathToDll}");
-                }
+				if (!File.Exists(_originalPathToDll))
+				{
+					throw new FileNotFoundException($"Unable to load DLL from {_originalPathToDll}");
+				}
 
-                _tempPathToDll = GetTempPathByConfig();
+				_tempPathToDll = GetTempPathByConfig();
 
-                CopyFile();
+				CopyFile();
 
-                _pointerLibrary = NativeMethods.LoadLibrary(_tempPathToDll);
+				_pointerLibrary = NativeMethods.LoadLibrary(_tempPathToDll);
 
-                if (_pointerLibrary == IntPtr.Zero)
-                {
-                    throw new Exception($"Unable to load DLL from {_originalPathToDll}");
-                }
+				if (_pointerLibrary == IntPtr.Zero)
+				{
+					throw new Exception($"Unable to load DLL from {_originalPathToDll}");
+				}
 
-                return _pointerLibrary;
-            }
-        }
+				return _pointerLibrary;
+			}
+		}
 
-        private static string GetFilePath(string pathToDll)
-        {
-            return pathToDll.StartsWith("~") || pathToDll.StartsWith("/")
-                ? HostingEnvironment.MapPath(pathToDll)
-                : pathToDll;
-        }
+		private static string GetFilePath(string pathToDll)
+		{
+			return pathToDll.StartsWith("~") || pathToDll.StartsWith("/")
+				? HostingEnvironment.MapPath(pathToDll)
+				: pathToDll;
+		}
 
-        private string GetTempPathByConfig()
-        {
-            if (_tempPath.IsNullOrEmpty())
-                return Path.GetTempFileName();
+		private string GetTempPathByConfig()
+		{
+			if (_tempPath.IsNullOrEmpty())
+				return Path.GetTempFileName();
 
-            var tempPathFixed = !_tempPath.EndsWith(@"\") ? _tempPath + @"\" : _tempPath;
-            tempPathFixed = GetFilePath(tempPathFixed);
+			var tempPathFixed = !_tempPath.EndsWith(@"\") ? _tempPath + @"\" : _tempPath;
+			tempPathFixed = GetFilePath(tempPathFixed);
 
-            return $@"{tempPathFixed}\{Path.GetRandomFileName()}";
-        }
+			return $@"{tempPathFixed}\{Path.GetRandomFileName()}";
+		}
 
-        private void CopyFile()
-        {
-            using (var stream = File.OpenRead(_originalPathToDll))
-            using (var writeStream = new FileStream(_tempPathToDll, FileMode.Create, FileAccess.Write))
-            {
-                stream.Seek(0, SeekOrigin.Begin);
-                stream.CopyTo(writeStream);
-            }
-        }
+		private void CopyFile()
+		{
+			using (var stream = File.OpenRead(_originalPathToDll))
+			using (var writeStream = new FileStream(_tempPathToDll, FileMode.Create, FileAccess.Write))
+			{
+				stream.Seek(0, SeekOrigin.Begin);
+				stream.CopyTo(writeStream);
+			}
+		}
 
-        private IntPtr LoadMethodOrFunction(string name)
-        {
-            var addressOfMethod = NativeMethods.GetProcAddress(_pointerLibrary, name);
-            if (addressOfMethod == IntPtr.Zero)
-            {
-                throw new Exception("Can't find {functionName} funtion in {originalPathToDll}");
-            }
+		private IntPtr LoadMethodOrFunction(string name)
+		{
+			var addressOfMethod = NativeMethods.GetProcAddress(_pointerLibrary, name);
+			if (addressOfMethod == IntPtr.Zero)
+			{
+				throw new Exception("Can't find {functionName} funtion in {originalPathToDll}");
+			}
 
-            return addressOfMethod;
-        }
+			return addressOfMethod;
+		}
 
-        public object GetDelegateFunction(string functionName, Type type)
-        {
-            var addressOfMethod = LoadMethodOrFunction(functionName);
-            var method = Marshal.GetDelegateForFunctionPointer(addressOfMethod, type);
-            return method;
-        }
+		public object GetDelegateFunction(string functionName, Type type)
+		{
+			var addressOfMethod = LoadMethodOrFunction(functionName);
+			var method = Marshal.GetDelegateForFunctionPointer(addressOfMethod, type);
+			return method;
+		}
 
-        public void Dispose()
-        {
-            //Dispose the library
-            if (_pointerLibrary != IntPtr.Zero)
-            {
-                NativeMethods.FreeLibrary(_pointerLibrary);
-            }
+		public void Dispose()
+		{
+			//Dispose the library
+			if (_pointerLibrary != IntPtr.Zero)
+			{
+				NativeMethods.FreeLibrary(_pointerLibrary);
+			}
 
-            //Delete temporary File
-            if (File.Exists(_tempPathToDll))
-            {
-                File.Delete(_tempPathToDll);
-            }
-        }
-    }
+			//Delete temporary File
+			if (File.Exists(_tempPathToDll))
+			{
+				File.Delete(_tempPathToDll);
+			}
+		}
+	}
 }


### PR DESCRIPTION
Hi @kamsar 

The steps to solve it:

- I added an extra parameter in ** Dianoga.Png.config **, and brief instructions on how to use it

```
Define the path of the temporary folder and grant read/write access to 
the Application Pool Identity User to avoid access and write errors.

If TempPath is empty or not defined, the GetTempPath function will be used, trying 
to get the temp folder in this order:

1. The path specified by the TMP environment variable
2. The path specified by the TEMP environment variable
3. The path specified by the USERPROFILE environment variable
4. The Windows directory

Examples:

The folder is already included in the project
<TempPath>/App_Data/Dianoga Tools/Temp</ TempPath>

Let Windows choose the temporary folder
<TempPath> </ TempPath>
```

- I created the folder ** Temp ** and inside a readme.txt file, because Git did not admit empty folder.

- I implemented the code in DynamicLinkLibrary.cs to use this new parameter.

- And finally, I added the test cases, to verify that is working fine.

I'm using Visual Studio, but I do not understand why tabs or spaces are replaced, even with the new .editorconfig settings. Please, don't get nervous. 

I hope you like it!

patocl
