### PR TITLE
HostingEnvironment.mapPath returns null

### DIFF
--- a/src/Dianoga/Optimizers/CommandLineToolOptimizer.cs
+++ b/src/Dianoga/Optimizers/CommandLineToolOptimizer.cs
@@ -20,7 +20,7 @@ namespace Dianoga.Optimizers
 			get { return _pathToExe; }
 			set
 			{
-				if (value.StartsWith("~") || value.StartsWith("/")) _pathToExe = HostingEnvironment.MapPath(value);
+				if (value.StartsWith("~") || value.StartsWith("/")) _pathToExe = HostingEnvironment.MapPath(value) ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, value.TrimStart('/', '\\'));
 				else _pathToExe = value;
 			}
 		}


### PR DESCRIPTION
We stumbled on an issue when running integration tests without IIS using OptimizeImage in the getMediaStream pipeline. In the CommandLineToolOptimizer there is an indirect dependency with IIS, nl. HostingEnvironment.mapPath returns null. I've added a fallback if the mapPath method returns null.