### PR TITLE
Implemented DianogaJpeg/SystemDrawingJpegOptimizer

### DIFF
--- a/src/Dianoga/Dianoga.csproj
+++ b/src/Dianoga/Dianoga.csproj
@@ -34,9 +34,9 @@
     <Reference Include="nQuant.Core">
       <HintPath>..\..\packages\nQuant.1.0.3\Lib\net40\nQuant.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Sitecore.Kernel.NoReferences.8.2.160729\lib\NET452\Sitecore.Kernel.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Sitecore.Kernel, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\skadden-sitecore2\lib\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -53,6 +53,7 @@
     <Compile Include="Invokers\MediaCacheAsync\Pipelines\Initialize\MediaCacheReplacer.cs" />
     <Compile Include="MediaOptimizer.cs" />
     <Compile Include="Invokers\MediaCacheAsync\OptimizingMediaCache.cs" />
+    <Compile Include="Optimizers\Pipelines\DianogaJpeg\SystemDrawingJpegOptimizer.cs" />
     <Compile Include="Optimizers\Pipelines\DianogaPng\PngOptimizer.cs" />
     <Compile Include="Optimizers\Pipelines\DianogaPng\PngQuantOptimizer.cs" />
     <Compile Include="Optimizers\OptimizerArgs.cs" />

--- a/src/Dianoga/Optimizers/Pipelines/DianogaJpeg/SystemDrawingJpegOptimizer.cs
+++ b/src/Dianoga/Optimizers/Pipelines/DianogaJpeg/SystemDrawingJpegOptimizer.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+
+namespace Dianoga.Optimizers.Pipelines.DianogaJpeg
+{
+	public class SystemDrawingJpegOptimizer : OptimizerProcessor
+	{
+		public virtual int StartQuality { get; set; }
+		public virtual int QualityStep { get; set; }
+		public virtual int SizeFactor { get; set; }
+
+		protected override void ProcessOptimizer(OptimizerArgs args)
+		{
+			string finalPath = null;
+			try
+			{
+				finalPath = DoProcessOptimizer(args);
+
+				args.IsOptimized = true;
+				using (var fileStream = File.OpenRead(finalPath))
+				{
+					args.Stream = new MemoryStream();
+					fileStream.CopyTo(args.Stream);
+				}
+			}
+			catch (Exception ex)
+			{
+				Sitecore.Diagnostics.Log.Error(ex.Message, ex, this);
+			}
+			finally
+			{
+				if (finalPath != null)
+				{
+					CleanUpTempFile(finalPath);
+				}
+			}
+		}
+
+		private string DoProcessOptimizer(OptimizerArgs args)
+		{
+			var tempInputPath = GetTempFilePath();
+			var tempOutputPath = GetTempFilePath();
+			long originalStreamLength = args.Stream.Length;
+			SaveStreamToPath(args.Stream, tempInputPath);
+
+			using (var img = Image.FromFile(tempInputPath))
+			{
+				int target = GetTargetSize(img);
+
+				if (originalStreamLength <= target)
+				{
+					Sitecore.Diagnostics.Log.Info(string.Format("SystemDrawingJpegOptimizer: Skipping, {0} < {1}", originalStreamLength, target), this);
+					return tempInputPath;
+				}
+
+				var encoder = GetEncoderInfo("image/jpeg");
+				var encoderParams = new EncoderParameters();
+				
+				for (var quality = StartQuality; quality > 0; quality -= QualityStep)
+				{
+					encoderParams.Param[0] = new EncoderParameter(Encoder.Quality, quality);
+
+					img.Save(tempOutputPath, encoder, encoderParams);
+					var info = new FileInfo(tempOutputPath);
+					if (info.Length <= target)
+					{
+						Sitecore.Diagnostics.Log.Info(string.Format("SystemDrawingJpegOptimizer: Optimized using quality {0}, {1} < {2}", quality, info.Length, target), this);
+						break;
+					}
+				}
+			}
+
+			CleanUpTempFile(tempInputPath);
+
+			return tempOutputPath;
+		}
+
+		private void SaveStreamToPath(Stream inputStream, string outputPath)
+		{
+			using (var outputStream = File.OpenWrite(outputPath))
+			{
+				inputStream.CopyTo(outputStream);
+				inputStream.Dispose();
+			}
+		}
+
+		private int GetTargetSize(Image img)
+		{
+			int max = Math.Max(img.Width, img.Height);
+
+			return max * SizeFactor;
+		}
+
+		private void CleanUpTempFile(string path)
+		{
+			if (File.Exists(path)) File.Delete(path);
+		}
+
+		private static ImageCodecInfo GetEncoderInfo(string mimeType)
+		{
+			return ImageCodecInfo.GetImageEncoders()
+				.Where(x => x.MimeType == mimeType)
+				.FirstOrDefault();
+		}
+
+		protected virtual string GetTempFilePath()
+		{
+			return Path.GetTempFileName();
+		}
+	}
+}


### PR DESCRIPTION
I created an optimizer for JPGs using basic System.Drawing classes.  The extra logic involves checking the original image's dimensions and using the largest dimension to calculate a target file size.  For example, if optimizing an 1600x900 with a "factor" of 100, the target size is 160KB.  The code starts at a top quality percentage (ex. 80), saves the image to a file and checks the resulting size.  If it hasn't gotten under the target size, it reduces the quality by a configurable step.

An example configuration node looks like this:

```
			<dianogaOptimizeJpeg>
				<processor type="Dianoga.Optimizers.Pipelines.DianogaJpeg.SystemDrawingJpegOptimizer, Dianoga">
					<startQuality>80</startQuality>
					<qualityStep>5</qualityStep>
					<sizeFactor>100</sizeFactor>
				</processor>
			</dianogaOptimizeJpeg>
```

I'm interested to hear your thoughts.