### PR TITLE
Log the right file sizes when an optimization is discarded

### DIFF
--- a/src/Dianoga/Optimizers/OptimizerProcessor.cs
+++ b/src/Dianoga/Optimizers/OptimizerProcessor.cs
@@ -74,9 +74,9 @@ namespace Dianoga.Optimizers
 
 				if (args.Stream.Length > originalStream.Length)
 				{
+					args.AddMessage($"{GetType().Name}: the optimized image resulted in a larger file size ({args.Stream.Length} vs {originalStream.Length}). Using the original instead.");
 					args.Stream.Dispose();
 					args.Stream = originalStream;
-					args.AddMessage($"{GetType().Name}: the optimized image resulted in a larger file size ({args.Stream.Length} vs {originalStream.Length}). Using the original instead.");
 				}
 				else
 				{


### PR DESCRIPTION
Just a fix for a tiny issue I came across while digging through logs: when validating an optimized stream and discarding it if it results in a larger file size, the log contained the original size twice instead of comparing it with the discarded one.