### PR TITLE
SC 9.1.1 with SXA

### DIFF
--- a/src/Dianoga.Tests/Dianoga.Tests.csproj
+++ b/src/Dianoga.Tests/Dianoga.Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dianoga.Tests</RootNamespace>
     <AssemblyName>Dianoga.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -16,6 +16,9 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,37 +38,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.14.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.14.0\lib\net45\FluentAssertions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.14.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.14.0\lib\net45\FluentAssertions.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Sitecore.Kernel.NoReferences.8.2.160729\lib\NET452\Sitecore.Kernel.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.1.0\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.1.0\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Optimizers\DianogaOptimizerProcessorTests.cs" />
@@ -77,9 +53,6 @@
     <Compile Include="Optimizers\Pipelines\DianogaWebP\WebPOptimizerTests.cs" />
     <Compile Include="Optimizers\TestOptimizerProcessor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Dianoga\Dianoga.csproj">
@@ -101,7 +74,20 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions">
+      <Version>5.8.0</Version>
+    </PackageReference>
+    <PackageReference Include="xunit">
+      <Version>2.4.1</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.analyzers">
+      <Version>0.10.0</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.core">
+      <Version>2.4.1</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Dianoga/Default Config Files/Dianoga.WebP.config.disabled
+++ b/src/Dianoga/Default Config Files/Dianoga.WebP.config.disabled
@@ -50,12 +50,14 @@
 		</mediaLibrary>
 
 		<!--Enable this section if you are running Dianoga under CDN. Otherwise CDN could cache webp response and return it for browsers that don't support it -->
-		<!--
+
 		<settings>
-			<setting name="MediaResponse.VaryHeader">
+			<setting name="Dianoga.WebP.ShowAlways" value="false"/>
+			
+			<!--<setting name="MediaResponse.VaryHeader">
 				<patch:attribute name="value">Accept</patch:attribute>
-			</setting>
+			</setting>-->
 		</settings>
-		-->
+
 	</sitecore>
 </configuration>

--- a/src/Dianoga/Dianoga.csproj
+++ b/src/Dianoga/Dianoga.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dianoga</RootNamespace>
     <AssemblyName>Dianoga</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -31,13 +31,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nQuant.Core">
-      <HintPath>..\..\packages\nQuant.1.0.3\Lib\net40\nQuant.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Sitecore.Kernel.NoReferences.8.2.160729\lib\NET452\Sitecore.Kernel.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -62,7 +55,6 @@
     <Compile Include="Optimizers\Pipelines\DianogaSvg\GzipSvgData.cs" />
     <Compile Include="Optimizers\Pipelines\DianogaSvg\SvgoOptimizer.cs" />
     <Compile Include="Optimizers\Pipelines\DianogaWebP\WebPOptimizer.cs" />
-    <Compile Include="Processors\Pipelines\DianogaOptimize\DisableDianogaForSite.cs" />
     <Compile Include="Processors\Pipelines\DianogaOptimize\ExtensionBasedOptimizer.cs" />
     <Compile Include="Processors\Pipelines\DianogaOptimize\DianogaOptimizeProcessor.cs" />
     <Compile Include="Processors\Pipelines\DianogaOptimize\PathExclusion.cs" />
@@ -101,9 +93,18 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="Dianoga.nuspec" />
-    <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <PackageReference Include="nQuant">
+      <Version>1.0.3</Version>
+    </PackageReference>
+    <PackageReference Include="Sitecore.Kernel">
+      <Version>9.1.1</Version>
+    </PackageReference>
+    <PackageReference Include="Sitecore.XA.Foundation.MediaRequestHandler">
+      <Version>4.8.1</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Dianoga/Dianoga.csproj
+++ b/src/Dianoga/Dianoga.csproj
@@ -42,6 +42,7 @@
     <Compile Include="Invokers\GetMediaStreamSync\OptimizeImage.cs" />
     <Compile Include="Invokers\MediaCacheAsync\Pipelines\GetMediaStream\ParseAcceptHeaders.cs" />
     <Compile Include="MediaRequestHandler.cs" />
+    <Compile Include="MediaRequestHandlerXA.cs" />
     <Compile Include="Optimizers\CommandLineToolOptimizer.cs" />
     <Compile Include="Optimizers\OptimizerProcessor.cs" />
     <Compile Include="Optimizers\Pipelines\DianogaJpeg\JpegOptimOptimizer.cs" />

--- a/src/Dianoga/MediaRequestHandlerXA.cs
+++ b/src/Dianoga/MediaRequestHandlerXA.cs
@@ -1,0 +1,36 @@
+﻿namespace Dianoga
+{
+	using Sitecore.Pipelines;
+	using Sitecore.XA.Foundation.MediaRequestHandler.Pipelines.MediaRequestHandler;
+	using Sitecore.XA.Foundation.MediaRequestHandler.Pipelines.MediaRequestHeaders;
+	using System.Linq;
+	using System.Web;
+
+	/// <summary>
+	/// Media request handler for projects using SXA
+	/// </summary>
+	public class MediaRequestHandlerXA : Sitecore.XA.Foundation.MediaRequestHandler.MediaRequestHandler
+	{
+		protected override bool DoProcessRequest(HttpContext context)
+		{
+			MediaRequestHandlerArgs mediaRequestHandlerArgs = new MediaRequestHandlerArgs(context);
+			CorePipeline.Run("mediaRequestHandler", mediaRequestHandlerArgs, failIfNotExists: false);
+			if (mediaRequestHandlerArgs.Aborted)
+			{
+				return mediaRequestHandlerArgs.Result;
+			}
+			if ((context?.Request.AcceptTypes != null && context.Request.AcceptTypes.Contains("image/webp")) 
+				|| Sitecore.Configuration.Settings.GetBoolSetting("Dianoga.WebP.ShowAlways", false))
+			{
+				mediaRequestHandlerArgs.Request.Options.CustomOptions["extension"] = "webp";
+			}
+			return DoProcessRequest(mediaRequestHandlerArgs.Context, mediaRequestHandlerArgs.Request, mediaRequestHandlerArgs.Media);
+		}
+
+		protected override void SendMediaHeaders(Sitecore.Resources.Media.Media media, HttpContext context)
+		{
+			base.SendMediaHeaders(media, context);
+			CorePipeline.Run("mediaRequestHeaders", new MediaRequestHeadersArgs() { Media = media, Context = context }, false);
+		}
+	}
+}


### PR DESCRIPTION
Updated NuGet references and changed to PackageReference.
Added handler to support projects using SXA.
Added option to always display WebP whether or not support is in header (eg. for CDN).