### PR TITLE
Generate media url param with proper query string ? or &

### DIFF
--- a/src/Dianoga/WebP/MediaProvider.cs
+++ b/src/Dianoga/WebP/MediaProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System.Web;
 using Sitecore.Data.Items;
 using Sitecore.Resources.Media;
+using Sitecore.Web;
 
 namespace Dianoga.WebP
 {
@@ -14,7 +15,7 @@ namespace Dianoga.WebP
 
 			if (item.MimeType.StartsWith("image") && HttpContext.Current.BrowserSupportsWebP())
 			{
-				url += "&extension=webp";
+				url = WebUtil.AddQueryString(url, "extension", "webp");
 			}
 
 			return url;
@@ -27,7 +28,7 @@ namespace Dianoga.WebP
 
 			if (item.MimeType.StartsWith("image") && HttpContext.Current.BrowserSupportsWebP())
 			{
-				url += "&extension=webp";
+				url = WebUtil.AddQueryString(url, "extension", "webp");
 			}
 
 			return url;


### PR DESCRIPTION
Generate media url param with proper query string ?= if no other parameters for WebP.
This fix some issues with images in JSS, like image placed in RTE.