### PR TITLE
Fixes #70: webp resizing for concurrent requests

### DIFF
--- a/src/Dianoga/Optimizers/Pipelines/DianogaWebP/WebPOptimizer.cs
+++ b/src/Dianoga/Optimizers/Pipelines/DianogaWebP/WebPOptimizer.cs
@@ -4,29 +4,12 @@ namespace Dianoga.Optimizers.Pipelines.DianogaWebP
 {
 	public class WebPOptimizer : CommandLineToolOptimizer
 	{
-		private string _originalAdditionalToolArguments;
 		public bool DisableResizing { get; set; }
 
 		public override void Process(OptimizerArgs args)
 		{
-
 			if (args.MediaOptions.BrowserSupportsWebP())
 			{
-				if (string.IsNullOrEmpty(_originalAdditionalToolArguments))
-				{
-					_originalAdditionalToolArguments = AdditionalToolArguments;
-				}
-
-				var transformationOptions = args.MediaOptions.GetTransformationOptions();
-				if (!DisableResizing && transformationOptions.ContainsResizing())
-				{
-					AdditionalToolArguments = $"{_originalAdditionalToolArguments} -resize {transformationOptions.Size.Width} {transformationOptions.Size.Height}";
-				}
-				else
-				{
-					AdditionalToolArguments = _originalAdditionalToolArguments;
-				}
-
 				base.Process(args);
 
 				if (args.IsOptimized)
@@ -43,6 +26,20 @@ namespace Dianoga.Optimizers.Pipelines.DianogaWebP
 		protected override string CreateToolArguments(string tempFilePath, string tempOutputPath)
 		{
 			return $"\"{tempFilePath}\" -o \"{tempOutputPath}\" ";
+		}
+
+		/// <summary>
+		/// Generate resize parameters
+		/// </summary>
+		protected override string GetMediaSpecificArguments(OptimizerArgs args)
+		{
+			var transformationOptions = args.MediaOptions.GetTransformationOptions();
+			if (!DisableResizing && transformationOptions.ContainsResizing())
+			{
+				return $"-resize {transformationOptions.Size.Width} {transformationOptions.Size.Height}";
+			}
+
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
WebPOptimizer customizes  AdditionalToolArguments property whenever an image is being processed. However, the value of that property is shared among concurrent optimizations. Hence, it was being overwritten by concurrent runs, messing with the -resize parameter for the tool.
Instead, the code should generate request (media) specific arguments to be used, and add those to the default arguments + additional tool arguments given in the config files.