### PR TITLE
SVGO Relative Path Config

### DIFF
--- a/src/Dianoga.Tests/Optimizers/Pipelines/DianogaSvg/SvgOptimizerTests.cs
+++ b/src/Dianoga.Tests/Optimizers/Pipelines/DianogaSvg/SvgOptimizerTests.cs
@@ -43,7 +43,7 @@ namespace Dianoga.Tests.Optimizers.Pipelines.DianogaSvg
 			//Pass configuration that disable removeViewBox plugin
 			Test(@"TestImages\small.svg",
 				@"..\..\..\..\Dianoga\Dianoga Tools\SVGO\svgo-win.exe",
-				"- --config \"..\\..\\..\\..\\Dianoga\\Dianoga Tools\\SVGO\\svgo.sample.config.js\"", out var args1, out var startingSize1);
+				"- --config svgo.sample.config.js", out var args1, out var startingSize1);
 			var file1 = new StreamReader(args1.Stream).ReadToEnd();
 
 			file1.Should().Contain("viewBox");

--- a/src/Dianoga/Optimizers/Pipelines/DianogaSvg/SvgoOptimizer.cs
+++ b/src/Dianoga/Optimizers/Pipelines/DianogaSvg/SvgoOptimizer.cs
@@ -27,6 +27,9 @@ namespace Dianoga.Optimizers.Pipelines.DianogaSvg
 				toolProcess.StartInfo.RedirectStandardOutput = true;
 				toolProcess.StartInfo.RedirectStandardError = true;
 
+				var directory = new DirectoryInfo(ExePath.Remove(ExePath.LastIndexOf("\\", StringComparison.InvariantCultureIgnoreCase)));
+				toolProcess.StartInfo.WorkingDirectory = directory.FullName;
+
 				var processOutput = new ConcurrentBag<string>();
 				toolProcess.ErrorDataReceived += (sender, eventArgs) => processOutput.Add(eventArgs.Data);
 


### PR DESCRIPTION
This is an addition to https://github.com/kamsar/Dianoga/issues/104

It will be nice to be able to pass configuration filename from the same directory, where `svgo-win.exe` is located. Otherwise, either an absolute path should be passed or a relative path from `c:\windows\system32\inetsrv` (default IIS working dir), which is not convenient.