### PR TITLE
Generate nextgen image format using custom header when accept header is not passed to origin server

### DIFF
--- a/src/Dianoga.Tests/NextGenFormats/HelpersTests.cs
+++ b/src/Dianoga.Tests/NextGenFormats/HelpersTests.cs
@@ -53,6 +53,72 @@ namespace Dianoga.Tests.NextGenFormats
 		}
 
 		[Fact]
+		public void GetSupportedFormats_ShouldNotCallDianogaGetSupportedFormatsPipeline_WhenNoCustomHeaderValue()
+		{
+			//Arrange
+			var context = new Mock<HttpContextBase>();
+			var request = new Mock<HttpRequestBase>();
+			context.Setup(ctx => ctx.Request).Returns(request.Object);
+			var headers = new NameValueCollection { { "customAccept", "" } };
+			request.SetupGet(x => x.Headers).Returns(headers);
+			var helpers = new Helpers();
+			var pipelineHelpers = new Mock<PipelineHelpers>();
+			helpers.PipelineHelpers = pipelineHelpers.Object;
+
+			//Act
+			var result = helpers.GetSupportedFormats(context.Object);
+
+			//Assert
+			result.Should().Be(String.Empty, "");
+			pipelineHelpers.Verify(m => m.RunDianogaGetSupportedFormatsPipeline(It.IsAny<string[]>()), Times.Never);
+		}
+
+		[Fact]
+		public void GetSupportedFormats_ShouldNotCallDianogaGetSupportedFormatsPipeline_WhenNoCustomHeader()
+		{
+			//Arrange
+			var context = new Mock<HttpContextBase>();
+			var request = new Mock<HttpRequestBase>();
+			context.Setup(ctx => ctx.Request).Returns(request.Object);
+			var headers = new NameValueCollection { };
+			request.SetupGet(x => x.Headers).Returns(headers);
+			var helpers = new Helpers();
+			var pipelineHelpers = new Mock<PipelineHelpers>();
+			helpers.PipelineHelpers = pipelineHelpers.Object;
+
+			//Act
+			var result = helpers.GetSupportedFormats(context.Object);
+
+			//Assert
+			result.Should().Be(String.Empty, "");
+			pipelineHelpers.Verify(m => m.RunDianogaGetSupportedFormatsPipeline(It.IsAny<string[]>()), Times.Never);
+		}
+
+		[Fact]
+		public void GetSupportedFormats_ShouldCallAndReturnValueFromdianogaGetSupportedFormatsPipeline_WhenNoAcceptTypesAndCustomHeaderIsPresent()
+		{
+			//Arrange
+			var context = new Mock<HttpContextBase>();
+			var request = new Mock<HttpRequestBase>();
+			context.Setup(ctx => ctx.Request).Returns(request.Object);			
+			var headers = new NameValueCollection { { "customAccept", "image/webp" } };
+			request.SetupGet(x => x.Headers).Returns(headers);
+			var queryString = new NameValueCollection();
+			queryString.Add("extension", "webp");
+			request.SetupGet(r => r.QueryString).Returns(queryString);
+			var helpers = new Helpers();
+			var pipelineHelpers = new Mock<PipelineHelpers>();
+			helpers.PipelineHelpers = pipelineHelpers.Object;
+
+			//Act
+			var result = helpers.GetCustomOptions(context.Object);
+
+			//Assert
+			result.Should().Be("webp", "");
+			pipelineHelpers.Verify(m => m.RunDianogaGetSupportedFormatsPipeline(It.IsAny<string[]>()), Times.Never);
+		}
+
+		[Fact]
 		public void GetCustomOptions_ShouldTakeValueFromQueryString_WhenExtensionQueryStringIsPresent()
 		{
 			//Arrange
@@ -98,6 +164,31 @@ namespace Dianoga.Tests.NextGenFormats
 
 			//Assert
 			result.Should().Be("webp,avif", "");
+			pipelineHelpers.Verify(m => m.RunDianogaGetSupportedFormatsPipeline(It.IsAny<string[]>()), Times.Once);
+		}
+
+		[Fact]
+		public void GetCustomOptions_ShouldTakeValueFromFromCustomHeader_WhenExtensionQueryStringIsEmptyAndAcceptTypeIsEmpty()
+		{
+			//Arrange
+			var context = new Mock<HttpContextBase>();
+			var request = new Mock<HttpRequestBase>();
+			context.Setup(ctx => ctx.Request).Returns(request.Object);
+			var headers = new NameValueCollection { { "customAccept", "image/webp" } };
+			request.SetupGet(x => x.Headers).Returns(headers);
+			var queryString = new NameValueCollection();
+			queryString.Add("extension", "");
+			request.SetupGet(r => r.QueryString).Returns(queryString);
+			var helpers = new Helpers();
+			var pipelineHelpers = new Mock<PipelineHelpers>();
+			pipelineHelpers.Setup(h => h.RunDianogaGetSupportedFormatsPipeline(It.IsAny<string[]>())).Returns("webp").Verifiable();
+			helpers.PipelineHelpers = pipelineHelpers.Object;
+
+			//Act
+			var result = helpers.GetCustomOptions(context.Object);
+
+			//Assert
+			result.Should().Be("webp", "");
 			pipelineHelpers.Verify(m => m.RunDianogaGetSupportedFormatsPipeline(It.IsAny<string[]>()), Times.Once);
 		}
 	}

--- a/src/Dianoga/NextGenFormats/Helpers.cs
+++ b/src/Dianoga/NextGenFormats/Helpers.cs
@@ -17,13 +17,24 @@ namespace Dianoga.NextGenFormats
 				return PipelineHelpers.RunDianogaGetSupportedFormatsPipeline(acceptTypes);
 			}
 
+			var customAccept = context?.Request?.Headers?["customAccept"];
+			if (!string.IsNullOrEmpty(customAccept))
+				return PipelineHelpers.RunDianogaGetSupportedFormatsPipeline(new string[] { customAccept });
+
 			return string.Empty;
 		}
 
 		public virtual bool CheckSupportedFormat(HttpContextBase context, string extension)
 		{
 			var acceptTypes = context?.Request?.AcceptTypes ?? new string[] { };
-			return acceptTypes.Any() && CheckSupportedFormat(string.Join(",", acceptTypes), extension);
+			if (acceptTypes.Any())
+				return CheckSupportedFormat(string.Join(",", acceptTypes), extension);
+
+			var customAccept = context?.Request?.Headers?["customAccept"];
+			if (!string.IsNullOrEmpty(customAccept))
+				return CheckSupportedFormat(customAccept, extension);
+
+			return false;
 		}
 
 		public virtual bool CheckSupportedFormat(string input, string extension)


### PR DESCRIPTION
When accept headers are not accepted or passed to origin server, use a custom header to know whether the client browser accepts next-gen formats and generate webp and other next-gen image formats. It can be [achieved using CDN rule engine](https://www.nehemiahj.com/2022/08/sitecore-dianoga-with-azure-cdn.html). 

Custom header name is "customAccept". 