### PR TITLE
Coveo Image Url

### DIFF
--- a/src/Dianoga/NextGenFormats/MediaProvider.cs
+++ b/src/Dianoga/NextGenFormats/MediaProvider.cs
@@ -31,8 +31,11 @@ namespace Dianoga.NextGenFormats
 
 		protected virtual string GetMediaUrl(MediaItem item, string url)
 		{
+
 			var helpers = new Helpers();
-			if (item.MimeType.StartsWith("image") && !url.Contains("extension"))
+			if (HttpContext.Current != null 
+			    && item.MimeType.StartsWith("image") 
+			    && !url.Contains("extension"))
 			{
 				var extensions = helpers.GetSupportedFormats(new HttpContextWrapper(HttpContext.Current));
 				if (!string.IsNullOrEmpty(extensions))


### PR DESCRIPTION
It fixes #135 
Coveo calls MediaProvider outside of HTTP Context. It causes exceptions.
To have Coveo compatibility, I have added a null check.